### PR TITLE
Re-enable previous features.

### DIFF
--- a/apt.txt
+++ b/apt.txt
@@ -82,12 +82,14 @@ multitail
 
 ## This section adds tools for desktop environment usage
 dbus-x11
+xfce4
+xfce4-panel
+xfce4-session
+xfce4-settings
 xorg
 xubuntu-icon-theme
-xfce4
-xfce4-goodies
-xclip
-xsel
+tigervnc-standalone-server
+
 firefox
 chromium-browser
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,41 +8,30 @@ dependencies:
   # Items required for basic level functionality
   - gh-scoped-creds==4.1
   - git==2.49.0
+  - jupyter_server==2.16.0
   - jupyter-resource-usage==1.1.1
   - jupyterhub==5.3.0
-  - jupyterlab==4.4.2
-  - jupyter_server==2.16.0
   - jupyterlab-git==0.51.1
+  - jupyterlab==4.4.2
+  - nbconvert==7.16.6
   - nbgitpuller==1.2.2
   - notebook==7.4.2
   - python==3.12
-  - nbconvert==7.16.6
 
   # vscode
   - code-server==4.100.2
   - jupyter-vscode-proxy==0.6
 
   # llm packages
-  - pystac-client==0.8.6
-  - odc-stac==0.4.0
-  - rioxarray==0.19.0
-  - rasterstats==0.20.0
   - langchain-chroma==0.2.4
   - leafmap[mablibregl]==0.46.0
+  - odc-stac==0.4.0
+  - pystac-client==0.8.6
+  - rasterstats==0.20.0
+  - rioxarray==0.19.0
 
   # other packages
   - altair==5.5.0
-  - duckdb-engine==0.15.0
-  - exactextract==0.2.2
-  - ibis-framework[pandas,duckdb]==10.5.0
-  - jupyterlab-myst==2.4.2
-  - latexmk==4.86a
-  - mystmd==1.3.27
-  - planetary-computer==1.0.0
-  - pypdf==5.5.0
-  - seaborn==0.13.2
-
-  # Other user-facing Python packages
   - bash_kernel==0.10.0
   - beautifulsoup4==4.13.4
   - black==25.1.0
@@ -51,36 +40,39 @@ dependencies:
   - cartopy==0.24.0
   - coverage==7.8.0
   - cython==3.1.1
-  - dask==2025.5.1
   - dask-labextension==7.0.0
+  - dask==2025.5.1
   - datascience==0.17.6
+  - duckdb-engine==0.15.0
+  - exactextract==0.2.2
   - fortran-magic==0.9
   - h5netcdf==1.6.1
   - h5py==3.13.0
   - hdf4==4.2.15
   - hdf5==1.14.6
-  - intake==2.0.8
+  - hypothesis==6.131.20
+  - ibis-framework[pandas,duckdb]==10.5.0
   - intake-esm==2025.2.3
   - intake-xarray==2.0.0
+  - intake==2.0.8
   - ipycanvas==0.13.3
   - ipydatagrid==1.4.0
   - ipympl==0.9.7
   - ipyparallel==9.0.1
   - ipywidgets==8.1.7
-  - jupyterlab-favorites==3.2.2
-  - jupyterlab-geojson==3.4.0
-
-  # LSP for JupyterLab/Python - enhanced completions/language support
-  - jupyterlab-lsp==5.1.0
-  - python-lsp-server==1.12.2
-
-  - jupyterlab-variableinspector==3.2.4
+  - jupyter_server_ydoc==2.0.2
   - jupyterlab_pygments==0.3.0
   - jupyterlab_server==2.27.3
+  - jupyterlab-favorites==3.2.2
+  - jupyterlab-geojson==3.4.0
+  - jupyterlab-lsp==5.1.0
+  - jupyterlab-myst==2.4.2
   - jupyterlab-spellchecker==0.8.4
-  - jupyter_server_ydoc==2.0.2
-  - matplotlib==3.10.3
+  - jupyterlab-variableinspector==3.2.4
+  - jupytext==1.17.1
+  - latexmk==4.86a
   - matplotlib-inline==0.1.7
+  - matplotlib==3.10.3
   - mock==5.2.0
   - nbdime==4.0.2
   - networkx==3.4.2
@@ -90,22 +82,27 @@ dependencies:
   - pep8==1.7.1
   - pillow==11.2.1
   - pip==25.1.1
+  - planetary-computer==1.0.0
   - plotly==6.1.0
   - pooch==1.8.2
   - prettytable==3.16.0
   - pyarrow==20.0.0
+  - pypdf==5.5.0
   - pytables==3.10.2
-  - pytest==8.3.5
   - pytest-cov==6.1.1
   - pytest-notebook==0.10.0
+  - pytest==8.3.5
+  - python-lsp-server==1.12.2
   - requests==2.32.3
   - ruyaml==0.91.0
   - scikit-image==0.25.2
   - scikit-learn==1.6.0
   - scipy==1.15.2
+  - seaborn==0.13.2
   - sqlparse==0.5.3
   - statsmodels==0.14.4
   - sympy==1.14
+  - tectonic==0.15.0 # Userland small TeX (similar to tinytex)
   - tk==8.6.13
   - tornado==6.5
   - tqdm==4.67.1
@@ -121,9 +118,7 @@ dependencies:
   - markdown-it-py==3.0.0
   - markupsafe==3.0.1
   - myst-nb==1.2.0
-
-  # Userland small TeX (similar to tinytex)
-  - tectonic==0.15.0
+  - mystmd==1.3.27
 
   # Packages that could be installed via the system package manager
   # (apt, homebrew, etc) but we bring them through here for better
@@ -136,38 +131,31 @@ dependencies:
   # Packages needed only on the hub (mostly linux)
   # If installing this environment on a personal machine,
   # comment these out (but not the pip section below)
+
+  - ipytest==0.14.2
+  - jupysql==0.11.1
+  - jupyter-server-proxy==4.4.0
+  - jupyter-syncthing-proxy==1.0.3 # syncthing for dropbox-like functionality
   - micro==2.0.14
+  - nbval==0.11.0
   - python-pdfkit==1.0.0
   - syncthing==1.29.6
   - websockify==0.13.0
-
-  - jupyter-server-proxy==4.4.0
 
   # Companions to tectonic, not yet available for desktop
   - texlab==5.22.1
   - chktex==1.7.9
 
-  # syncthing for dropbox-like functionality
-  - jupyter-syncthing-proxy==1.0.3
-
-  - jupysql==0.11.1
-  - nbval==0.11.0
-
-  - ipytest==0.14.2
-  # pulled in by ottr, if not pinned to 1.16.2, 1.16.3 causes DH-323
-  #- jupytext==1.16.2
 
 # Packages not available on conda-forge, installed through pip
   - pip:
 
     # Packages needed only on the hub (mostly linux)
     - jupyter-remote-desktop-proxy==3.0.1
-
-    # Needed for RTC on NFS-backed hubs
-    #- git+https://github.com/berkeley-dsep-infra/tmpystore.git@84765e1
-
     - git+https://github.com/shaneknapp/python-popularity-contest.git@add-error-handling
-
     # for notebook exporting
     - nb2pdf==0.6.2
     - nbpdfexport==0.2.1
+
+    # Needed for RTC on NFS-backed hubs
+    #- git+https://github.com/berkeley-dsep-infra/tmpystore.git@84765e1


### PR DESCRIPTION
Install vncserver for jupyter-remote-desktop-proxy. Re-add previously installed conda-forge packages after resolving dependency issues.