### PR TITLE
back to jupyter-ai 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,13 +25,14 @@ dependencies:
   - jupyter-vscode-proxy==0.6
 
   # llm packages
+  - jupyter-ai==2.31.6
+  - langchain-openai==0.3.34
   - langchain-chroma==0.2.4
   - leafmap[mablibregl]==0.47.2
   - odc-stac==0.4.0
   - pystac-client==0.8.6
   - rasterstats==0.20.0
   - rioxarray==0.19.0
-  - jupyter-ai==3.0.0b7
 
   # other packages
   - altair==5.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,8 @@
 name: stat159
 
 channels:
-  - conda-forge/label/jupyter-ai_rc
+  # need jupyter-ai_rc for juptyer-ai 3
+  # - conda-forge/label/jupyter-ai_rc
   - conda-forge
 
 dependencies:
@@ -26,7 +27,7 @@ dependencies:
 
   # llm packages
   - jupyter-ai==2.31.6
-  - langchain-openai==0.3.34
+  - langchain-openai==0.3.33
   - langchain-chroma==0.2.4
   - leafmap[mablibregl]==0.47.2
   - odc-stac==0.4.0
@@ -79,7 +80,7 @@ dependencies:
   - nbdime==4.0.2
   - networkx==3.5
   - numba==0.61.2
-  - numpy==2.2.6
+  - numpy==1.26.4
   - pandas==2.3.0
   - pep8==1.7.1
   - pillow==11.2.1


### PR DESCRIPTION
juptyer-ai 3 does not appear to be ready to be used except by highly experimental early adopters ready for a lot of undocumented behavior and rough edges

- several  key features like completions, etc. entirely missing
- all slash commands appear to be removed, and there doesn't appear to be any substitute that I can find
- v3 docs still largely describe v2 features that have been removed, so I think it would be confusing for students